### PR TITLE
when converting int to str and but already str, return as-is

### DIFF
--- a/bin/biomartian
+++ b/bin/biomartian
@@ -86,7 +86,11 @@ def _turn_int_cols_with_na_into_str(map_df, outtype):
     outcol = map_df[outtype]
 
     is_float = issubclass(outcol.dtype.type, float)
-    all_are_ints = all(equal(mod(outcol.dropna(), 1), 0))
+
+    try:
+        all_are_ints = all(equal(mod(outcol.dropna(), 1), 0))
+    except TypeError:
+        return map_df
 
     if is_float and all_are_ints:
         map_df[outtype] = map_df[outtype].astype(str).apply(


### PR DESCRIPTION
First: Awesome package, I think I will be using this a lot. I especially love the caching.

Second: Trying to get human homologs of mouse genes, like this:
```
# ex.txt
id
ENSMUSG00000028180
ENSMUSG00000028182
ENSMUSG00000028185
ENSMUSG00000028184
ENSMUSG00000028187
ENSMUSG00000028186
ENSMUSG00000028189
ENSMUSG00000028188
ENSMUSG00000035429
```

```
biomartian \
ex.txt \
-d mmusculus_gene_ensembl \
-c id \
-o hsapiens_homolog_ensembl_gene \
-i ensembl_gene_id
```
Resulted in:
```
Traceback (most recent call last):
  File "../bin/biomartian", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "../bin/biomartian", line 144, in <module>
    mart)
  File "../bin/biomartian", line 67, in append_data_to_infile
    outtype)
  File "../bin/biomartian", line 89, in _turn_int_cols_with_na_into_str
    all_are_ints = all(equal(mod(outcol.dropna(), 1), 0))
TypeError: not all arguments converted during string formatting
```
because my `outtype` column was a string and it was trying to call `mod()` on string type.

So this pull request fixes it. I wasn't sure where to put a test; hopefully this description is enough to reproduce.
 
